### PR TITLE
Gracefully skip emtpy files

### DIFF
--- a/blackbricks/cli.py
+++ b/blackbricks/cli.py
@@ -24,7 +24,7 @@ def process_files(
     for file_ in files:
         content = file_.content
 
-        if HEADER not in content.lstrip().splitlines()[0]:
+        if not content.lstrip() or HEADER not in content.lstrip().splitlines()[0]:
             # Not a Databricks notebook - skip
             continue
 


### PR DESCRIPTION
otherwise having empty files (like .gitkeep) in a directory will lead to an IndexError: list index out of range