### PR TITLE
Add code coverage to files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+# Ignore whitespace, line length, line break
+ignore = E203,E501,W503
+
+# Extend line length and complexity to match project
+max-line-length = 190
+max-complexity = 15
+
+# Exclude test notebook
+exclude = test_notebooks\test.py

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,68 @@
+from pathlib import Path
+
+import click.testing
+
+import pytest
+from blackbricks.files import resolve_filepaths, File, LocalFile, RemoteNotebook
+
+def test_file():
+    """Test the File dataclass."""
+    expected = File(path='test123')
+
+    result = File("test123")
+
+    assert result == expected
+
+def test_file_should_not_use_content():
+    """Test the File dataclass should not allow content."""
+    file = File("test456")
+
+    with pytest.raises(NotImplementedError) as pytest_wrapped_e:
+        file.content
+
+    assert pytest_wrapped_e.type == NotImplementedError
+
+
+def test_file_should_not_set():
+    """Test the File dataclass should not allow content."""
+    file = File("test456")
+
+    with pytest.raises(NotImplementedError) as pytest_wrapped_e:
+        file.content = "test789"
+
+    assert pytest_wrapped_e.type == NotImplementedError
+
+
+def test_localfile():
+    """Test the LocalFile dataclass."""
+    expected = LocalFile(path='test123')
+
+    result = LocalFile("test123")
+
+    assert result == expected
+
+
+def test_resolve_filepaths():
+    """Test that the resolve_filepaths function works as expected."""
+    file_paths = resolve_filepaths(["tests\\test_files.py"])
+
+    result = Path(file_paths[0]).is_file()
+
+    assert result is True
+
+
+def test_no_unresolved_filepaths():
+    """Test that typer exits with no such file or directory error."""
+    with pytest.raises(click.exceptions.Exit) as pytest_wrapped_e:
+        resolve_filepaths(["tests\\test123"])
+
+    assert pytest_wrapped_e.type == click.exceptions.Exit
+
+
+def test_resolve_filepaths_adds_dir():
+    """Test that the resolve_filepaths adds a directory."""
+    file_paths = resolve_filepaths(["tests\\"])
+
+    result = Path(file_paths[0]).is_file()
+
+    assert result is True


### PR DESCRIPTION
Add code coverage to files.  Skipped databricks remote and write file.   Recommend adding pytest-cov and pytest-mock to Poetry dependencies.

```shell
----------- coverage: platform win32, python 3.9.0-final-0 -----------
Name                             Stmts   Miss  Cover   Missing
--------------------------------------------------------------
blackbricks\__init__.py              1      0   100%
blackbricks\blackbricks.py          98     15    85%   56, 79, 84, 86, 88-94, 106-107, 208-212
blackbricks\cli.py                  63     30    52%   29, 37-44, 46-52, 54, 83-89, 94-97, 171-193, 197
blackbricks\databricks_sync.py      58     46    21%   14-17, 31-33, 36-43, 46-47, 57-142
blackbricks\files.py                44      4    91%   35-36, 45, 49
--------------------------------------------------------------
TOTAL                              264     95    64%
```