### PR TITLE
fix: avoid failing on quoted cell dividers

### DIFF
--- a/blackbricks/blackbricks.py
+++ b/blackbricks/blackbricks.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from typing import Literal, Union
 
@@ -28,7 +29,8 @@ def format_str(content: str, config: FormatConfig = FormatConfig()) -> str:
     :param config: An object holding the desired formatting options.
     :return: The content of the file, formatted according to the configuration.
     """
-    cells = content.replace(HEADER, "", 1).split(COMMAND)
+    content = content.replace(HEADER, "", 1)
+    cells = re.split(f"^{COMMAND}.*$", content, flags=re.MULTILINE)
 
     output_cells = []
     for cell in cells:


### PR DESCRIPTION
This fixes a bug where any code with the `# COMMAND ------` cell divisor comment would cause parse errors or unwanted cell splits.

Example:

```python
print("""\n# COMMAND ----------""")
````

This would fail on versions <=1.0.3

Now only lines containing only this cell divisor (disregarding trailing whitespace) will be treated as cell divisors.