### PR TITLE
add cli option for formatting with newline eof

### DIFF
--- a/blackbricks/blackbricks.py
+++ b/blackbricks/blackbricks.py
@@ -16,6 +16,7 @@ class FormatConfig:
     "Data-only class to hold format configuration options and their defaults."
     line_length: int = black.const.DEFAULT_LINE_LENGTH
     sql_upper: bool = True
+    end_in_newline: bool = False
 
 
 def format_str(content: str, config: FormatConfig = FormatConfig()) -> str:
@@ -72,7 +73,10 @@ def format_str(content: str, config: FormatConfig = FormatConfig()) -> str:
 
         output_ws_normalized += line + "\n"
 
-    return output_ws_normalized.strip()
+    output_ws_normalized = output_ws_normalized.strip()
+    if config.end_in_newline:
+        output_ws_normalized += "\n"
+    return output_ws_normalized
 
 
 def _format_sql_cell(

--- a/blackbricks/cli.py
+++ b/blackbricks/cli.py
@@ -131,6 +131,12 @@ def main(
         metavar="NAME",
         help="If using --remote, which Databricks profile to use.",
     ),
+    end_with_newline: bool = typer.Option(
+        False,
+        "--newline",
+        "-n",
+        help="If this option is used, all notebooks will end in newline.",
+    ),
     line_length: int = typer.Option(
         black.const.DEFAULT_LINE_LENGTH, help="How many characters per line to allow."
     ),
@@ -215,7 +221,11 @@ def main(
 
     n_changed_files = process_files(
         files,
-        format_config=FormatConfig(line_length=line_length, sql_upper=sql_upper),
+        format_config=FormatConfig(
+            line_length=line_length,
+            sql_upper=sql_upper,
+            end_in_newline=end_with_newline,
+        ),
         diff=diff,
         check=check,
     )

--- a/test_notebooks/test_end_newline.py
+++ b/test_notebooks/test_end_newline.py
@@ -1,0 +1,78 @@
+# Databricks notebook source
+from pyspark.sql import SQLContext
+
+sqlContext = SQLContext(spark)
+
+# COMMAND ----------
+
+# DBTITLE 1,Title for a python cell
+dw_management = spark.table("this.that").select("some_id").join(spark.table("other.that"), "other_id")
+
+
+def test_func(input_param):
+    """
+    :param   input_param: input
+    """
+    return None
+
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC # Markdown heading!
+# MAGIC  - And a list element
+
+# COMMAND ----------
+
+# MAGIC %sh
+# MAGIC ls -l
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC ALTER TABLE this.that
+# MAGIC SET TBLPROPERTIES (delta.autoOptimize = TRUE);
+# MAGIC
+# MAGIC
+# MAGIC ALTER TABLE other.that
+# MAGIC SET TBLPROPERTIES (delta.autoOptimize = TRUE);
+
+# COMMAND ----------
+
+# DBTITLE 1,Title for an SQL cell
+# MAGIC %sql
+# MAGIC SELECT country,
+# MAGIC        product,
+# MAGIC        SUM(profit)
+# MAGIC FROM sales
+# MAGIC LEFT JOIN x ON x.id=sales.k
+# MAGIC GROUP BY country,
+# MAGIC          product
+# MAGIC HAVING f > 7
+# MAGIC AND fk=9
+# MAGIC LIMIT 5;
+
+# COMMAND ----------
+
+# MAGIC %sql  -- nofmt
+# MAGIC CREATE OR REPLACE VIEW abc.test AS
+# MAGIC   (SELECT foo.bar,
+# MAGIC           foo.fizz,  -- a comment
+# MAGIC           foo.fizzbar,
+# MAGIC           foo.bazz
+# MAGIC    FROM cba.tset foo);
+# MAGIC
+# MAGIC
+# MAGIC CREATE OR REPLACE VIEW asd.dsa AS
+# MAGIC   (SELECT bar.foo,
+# MAGIC           COLLECT_SET(bar.fizz)[0],
+# MAGIC           FIRST(bar.baz)
+# MAGIC    FROM dsa.asd bar
+# MAGIC    GROUP BY bar.fizzbuzz);
+
+# COMMAND ----------
+
+# MAGIC %sql
+# MAGIC SELECT id
+# MAGIC FROM test_table
+# MAGIC LIMIT 1

--- a/tests/test_check_test_notebook.py
+++ b/tests/test_check_test_notebook.py
@@ -18,3 +18,16 @@ def test_check_test_notebook():
             check=True,
         )
     assert f.getvalue() == "All done!\n1 files would be left unchanged\n"
+
+
+def test_check_test_notebook_with_newline():
+    """Test formatting notebooks that should end in newline."""
+
+    f = StringIO()
+    with redirect_stdout(f):
+        process_files(
+            [LocalFile(Path(__file__).parent.parent / "test_notebooks" / "test_end_newline.py")],
+            format_config=FormatConfig(end_in_newline=True),
+            check=True,
+        )
+    assert f.getvalue() == "All done!\n1 files would be left unchanged\n"


### PR DESCRIPTION
Added CLI option for formatting notebooks with newline at eof.

E.g. 
`blackbricks --newline`

should add a "\n" character to the end of each formatted file.